### PR TITLE
Updated plugin to fit with new Cordova/Ionic plugin specs (NPM)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "com.red_folder.phonegap.plugin.backgroundservice",
+  "version": "2.0.0",
+  "description": "Framework code that allows the development and operation of an Android Background Service.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Squix/cordova-background-service.git"
+  },
+  "keywords": [
+    "background",
+    "cordova"
+  ],
+  "platforms": [
+    "android"
+  ],
+  "engines": [
+    {
+      "name": "cordova",
+      "version": ">=3.0.0"
+    }
+  ],
+  "author": "Red-Folder",
+  "license": "Apache 2.0",
+  "bugs": {
+    "url": "https://github.com/Red-Folder/bgs-core/issues"
+  },
+  "homepage": "https://github.com/Red-Folder/bgs-core#readme"
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,37 +2,33 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="com.red_folder.phonegap.plugin.backgroundservice"
-        version="2.0.0">
-
-    <name>Background Service Plugin - Core logic</name>
-
-    <description>
-        Framework code that allows the development and operation of an Android Background Service.
-    </description>
-
-    <license>Apache 2.0</license>
+        version="2.0.0"
+>
 
     <engines>
         <engine name="cordova" version=">=3.0.0"/>
     </engines>
-    
-    <!-- android -->
-    <platform name="android">
 
-	    <js-module src="www/backgroundService.js" name="BackgroundService">
-		</js-module>
+    <name>Background Service Plugin - Core logic</name>
+    <description>Framework code that allows the development and operation of an Android Background Service.</description>
+    <license>Apache 2.0</license>
+    <keywords>cordova,background</keywords>
+    
+    <js-module src="www/backgroundService.js" name="BackgroundService">
+    </js-module>
+
+    <platform name="android">
 
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="BackgroundServicePlugin">
-                <param name="android-package" value="com.red_folder.phonegap.plugin.backgroundservice.BackgroundServicePlugin"/>
+                 <param name="android-package" value="com.red_folder.phonegap.plugin.backgroundservice.BackgroundServicePlugin"/>
             </feature>
-    
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest">
             <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
         </config-file>
-        
+
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
   
             <receiver android:name="com.red_folder.phonegap.plugin.backgroundservice.BootReceiver">
@@ -42,17 +38,16 @@
             </receiver>
             
         </config-file>
-        
-		
-        <source-file src="src/android/BackgroundService.java" target-dir="src/com/red_folder/phonegap/plugin/backgroundservice" />
+
+         <source-file src="src/android/BackgroundService.java" target-dir="src/com/red_folder/phonegap/plugin/backgroundservice" />
         <source-file src="src/android/BackgroundServicePlugin.java" target-dir="src/com/red_folder/phonegap/plugin/backgroundservice" />
         <source-file src="src/android/BackgroundServicePluginLogic.java" target-dir="src/com/red_folder/phonegap/plugin/backgroundservice" />
         <source-file src="src/android/BootReceiver.java" target-dir="src/com/red_folder/phonegap/plugin/backgroundservice" />
         <source-file src="src/android/PropertyHelper.java" target-dir="src/com/red_folder/phonegap/plugin/backgroundservice" />
         <source-file src="src/android/ReflectionHelper.java" target-dir="src/com/red_folder/phonegap/plugin/backgroundservice" />
-		
+        
         <source-file src="aidl/android/BackgroundServiceApi.aidl" target-dir="src/com/red_folder/phonegap/plugin/backgroundservice" />
         <source-file src="aidl/android/BackgroundServiceListener.aidl" target-dir="src/com/red_folder/phonegap/plugin/backgroundservice" />
-		
+
     </platform>
 </plugin>


### PR DESCRIPTION
I added package.json and tweaked plugin.xml to allow usage of this plugin with the new Cordova/Ionic CLI using NPM. 
Without these ajustements, "cordova plugin add https://github.com/Red-Folder/bgs-core.git" command doesn't work.
Tested on my project, it works fine.