### PR TITLE
fix(BackgroundServicePluginLogic): replace null with JSONObject.NULL

### DIFF
--- a/src/android/BackgroundServicePluginLogic.java
+++ b/src/android/BackgroundServicePluginLogic.java
@@ -711,10 +711,10 @@ public class BackgroundServicePluginLogic {
 				try { result.put("TimerMilliseconds", getTimerMilliseconds()); } catch (Exception ex) {Log.d(LOCALTAG, "Adding TimerMilliseconds to JSONObject failed", ex);};
 			} else {
 				try { result.put("ServiceRunning", false); } catch (Exception ex) {Log.d(LOCALTAG, "Adding ServiceRunning to JSONObject failed", ex);};
-				try { result.put("TimerEnabled", null); } catch (Exception ex) {Log.d(LOCALTAG, "Adding TimerEnabled to JSONObject failed", ex);};
-				try { result.put("Configuration", null); } catch (Exception ex) {Log.d(LOCALTAG, "Adding Configuration to JSONObject failed", ex);};
-				try { result.put("LatestResult", null); } catch (Exception ex) {Log.d(LOCALTAG, "Adding LatestResult to JSONObject failed", ex);};
-				try { result.put("TimerMilliseconds", null); } catch (Exception ex) {Log.d(LOCALTAG, "Adding TimerMilliseconds to JSONObject failed", ex);};
+				try { result.put("TimerEnabled", JSONObject.NULL); } catch (Exception ex) {Log.d(LOCALTAG, "Adding TimerEnabled to JSONObject failed", ex);};
+				try { result.put("Configuration", JSONObject.NULL); } catch (Exception ex) {Log.d(LOCALTAG, "Adding Configuration to JSONObject failed", ex);};
+				try { result.put("LatestResult", JSONObject.NULL); } catch (Exception ex) {Log.d(LOCALTAG, "Adding LatestResult to JSONObject failed", ex);};
+				try { result.put("TimerMilliseconds", JSONObject.NULL); } catch (Exception ex) {Log.d(LOCALTAG, "Adding TimerMilliseconds to JSONObject failed", ex);};
 			}
 
 			try { result.put("RegisteredForBootStart", isRegisteredForBootStart()); } catch (Exception ex) {Log.d(LOCALTAG, "Adding RegisteredForBootStart to JSONObject failed", ex);};


### PR DESCRIPTION
This was giving build errors on cordova-android 7.1.3

```
...
Execution failed for task ':app:compileReleaseJavaWithJavac'.
...
both method put(String,Collection) in JSONObject and method put(String,Map) in JSONObject match
...
```